### PR TITLE
Fix error in GetDuration when thumbnails disabled (--no-thumb)

### DIFF
--- a/internal/thumbnails/thumbnails.go
+++ b/internal/thumbnails/thumbnails.go
@@ -38,7 +38,7 @@ func Init() {
 }
 
 func GetDuration(file string) (float64, error) {
-	if !utils.IsVideo(file) {
+	if !Available || !utils.IsVideo(file) {
 		return 0, ErrNotVideo
 	}
 	var secs string
@@ -162,3 +162,4 @@ func Get(id string, file string) (string, error) {
 	}
 	return filepath.Join(utils.ThumbDir, h, fmt.Sprintf("%v.jpg", id)), nil
 }
+


### PR DESCRIPTION
Problem: error when ```~/.avrp/nothumb``` exists causing ```GetDuration``` to fail

When the persistent no-thumbnail marker file (~/.avrp/nothumb) exists, avrp currently fails to get the duration of videos with an error like:
```
2026/01/02 12:37:25 thumbnails.go:60: ERR - Failed to get Duration for /share/testbestand.mp4 - exec: no command
```

This is caused by the following code in initFfmpeg():
```
func initFfmpeg() bool {
    if NoThumb() {
        return false
    }
    ...
    binFfprobe = filepath.Join(utils.FfmpegDir, "bin", ffprobe)
    ...
}
```

Because the function returns early if NoThumb() is true, the binFfprobe variable is never set, causing exec.Command(binFfprobe, args...) in GetDuration() to fail with exec: no command.

**Proposed fix**

Update GetDuration() to check the Available flag (which indicates whether ffmpeg/ffprobe were properly initialized), and if Available is false, skip trying to get the duration:
```
func GetDuration(file string) (float64, error) {
    if !Available || !utils.IsVideo(file) {
        return 0, ErrNotVideo
    }
    ...
}
```

This prevents GetDuration() from attempting to run ffprobe when it is not available, avoiding the error when thumbnails are disabled.